### PR TITLE
readme: Add `use` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ You can use this component to render both static and dynamic markdown.
 
 ```rust
 use leptos::*;
+use leptos_markdown::Markdown;
 
 {
     ...


### PR DESCRIPTION
This is needed to make the `Static markdown` example in the README to work.